### PR TITLE
Add agent run inspection debugging tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Vibe coding is a mindset for AI assisted development where you "vibe" with the A
     - If the first fix doesn't work, explain the outcome and try again. 
     - The AI is often capable of resolving it.
 
+- **Inspect Agent Runs**:
+    - When an AI task is slow, costly, or repeatedly failing, review the saved session logs instead of judging only the final answer.
+    - Tools like [agenttrace](https://github.com/luoyuctl/agenttrace) can surface token usage, cost, latency gaps, tool failures, and retry loops across local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, Qwen Code, Cline, OpenCode/OpenClaw, and Kimi CLI session logs.
+
 - **Iterate and Refine**:
     - Embrace rapid iteration.
     - Don't worry about perfect designs initially.

--- a/testing_and_debugging_guide/README.md
+++ b/testing_and_debugging_guide/README.md
@@ -9,6 +9,10 @@
     - If the first fix doesn't work, explain the outcome and try again. 
     - The AI is often capable of resolving it.
 
+- **Inspect Agent Runs**:
+    - When an AI task is slow, costly, or repeatedly failing, review the saved session logs instead of judging only the final answer.
+    - Tools like [agenttrace](https://github.com/luoyuctl/agenttrace) can surface token usage, cost, latency gaps, tool failures, and retry loops across local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, Qwen Code, Cline, OpenCode/OpenClaw, and Kimi CLI session logs.
+
 - **Iterate and Refine**:
     - Embrace rapid iteration.
     - Don't worry about perfect designs initially.


### PR DESCRIPTION
## Summary

- Add a Testing and Debugging tip to inspect saved AI agent runs when tasks are slow, costly, or repeatedly failing
- Mention agenttrace as one local tool for surfacing token usage, cost, latency gaps, tool failures, and retry loops
- Keep the top-level README and testing_and_debugging_guide/README.md in sync

## Validation

- git diff --check