### PR TITLE
Add guarded agent loop setup tip

### DIFF
--- a/setup_and_planning_guide/README.md
+++ b/setup_and_planning_guide/README.md
@@ -5,6 +5,12 @@
     - Begin your project by cloning a template from GitHub or another source to provide a solid foundation. 
     - e.g. On Cursor, you can use the `Start from Repo` feature. 
 
+- **Use a Guarded Agent Loop for Longer Runs**:
+
+    - For multi-step agent work, use a scaffold that keeps plans, specs, tests, and commits explicit instead of relying on one long chat.
+    - Example: [Ralph Harness](https://github.com/rxdt/py_ralph_frame) runs Claude Code, Codex CLI, or Gemini CLI through fresh-context iterations with git hooks, CI verification, and time caps.
+    - Try it with `uvx ralph-harness demo`.
+
 - **Create a Comprehensive Plan**: 
     - Use an AI assistant like Claude or ChatGPT to create a detailed plan in markdown. 
     - Ask it clarifying questions and have it critique its own plan, then regenerate until it's solid. 


### PR DESCRIPTION
Adds a concise setup/planning tip for longer-running AI coding sessions: use a guarded loop with explicit specs, tests, commits, and time caps instead of relying on one long chat.

Uses Ralph Harness as a concrete example because it works with Claude Code, Codex CLI, and Gemini CLI and is runnable from PyPI:

```sh
uvx ralph-harness demo
```

Kept the change to one small bullet in the existing setup guide.