### PR TITLE
Add a UI finish gate to testing guidance

### DIFF
--- a/testing_and_debugging_guide/README.md
+++ b/testing_and_debugging_guide/README.md
@@ -13,3 +13,10 @@
     - Embrace rapid iteration.
     - Don't worry about perfect designs initially.
     - Improve them step by step.
+
+- **Stop UI Slop With a Finish Gate**:
+    - Before implementation, define a small design contract: product intent, visual rules, reference screens, and required interaction states.
+    - Review the result at phone and desktop widths, including empty, loading, error, disabled, and success states.
+    - Reject stock card grids, placeholder copy, decorative effects, or interactions that could belong to any product.
+    - Give the agent screenshot evidence and exact mismatches, then require another pass until every mismatch is resolved.
+    - A public UI reference library and reusable agent finish-gate workflow are available at https://uizze.com.


### PR DESCRIPTION
## Summary

Adds a practical UI finish gate to the testing and debugging guide:

- define a small design contract before implementation;
- review responsive widths and non-happy-path states;
- reject generic layouts, copy, effects, and interactions;
- give the agent screenshot evidence and exact mismatches;
- repeat until the mismatches are resolved.

The result is reusable guidance, not a tool-list advertisement. Disclosure: I help maintain UIZZE, the linked public UI reference and finish-gate workflow.

## Validation

- `git diff --check` — passes
- scoped content assertions — pass
- linked UIZZE URL — HTTP 200
- exactly one untracked UIZZE URL; no pricing, credentials, or metrics added
