### PR TITLE
Add interface contract planning guidance

### DIFF
--- a/setup_and_planning_guide/README.md
+++ b/setup_and_planning_guide/README.md
@@ -10,6 +10,11 @@
     - Ask it clarifying questions and have it critique its own plan, then regenerate until it's solid. 
     - This plan becomes your instruction manual for the coding process. Save this plan in `plan.md` (or `Claude.md` if you run `/init` in Cursor) so the AI can reference it anytime.
 
+- **Define the Interface Contract Before Coding**:
+    - Document design tokens, responsive breakpoints, component states, accessibility requirements, and motion constraints before asking an AI agent to build the interface.
+    - Keep the contract in the repository so the agent can use the same rules across prompts and implementation passes.
+    - The free, MIT-licensed [Vibe Coding UI Specification](https://horizonx.so/resources/vibe-coding-ui-specification) provides a reusable checklist for this step.
+
 - **Secure Your Secrets**: 
     - Always store API keys, tokens, and other sensitive data in environment files (`.env`). 
     - Never hard-code them directly into your source code. 


### PR DESCRIPTION
## Summary

Adds one planning practice to the dedicated setup guide: define the interface contract before AI-assisted implementation. The checklist covers design tokens, responsive breakpoints, component states, accessibility, and motion, and points to a free MIT-licensed specification that readers can keep in their repository.

## Scope

- 1 documentation file
- 5 additions, 0 deletions
- no change to the Top 10 tools list
- no pricing, rankings, or promotional claims

## Disclosure

I’m Marcelo Cedeño, founder of HorizonX, the commercial maintainer of the linked free MIT-licensed resource. HorizonX also sells paid UI and code products. AI assistance was used to research the repository, draft the guidance, and verify the final diff. Please include the reference only if it independently improves this guide. No payment, sponsorship, reciprocal link, guaranteed placement, featured status, or preferred anchor is requested.

Verification contact: support@horizonx.so.
