### PR TITLE
Setup and Planning: link a staged prompt template for the planning step

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Vibe coding is a mindset for AI assisted development where you "vibe" with the A
     - Use an AI assistant like Claude or ChatGPT to create a detailed plan in markdown. 
     - Ask it clarifying questions and have it critique its own plan, then regenerate until it's solid. 
     - This plan becomes your instruction manual for the coding process. Save this plan in `plan.md` (or `Claude.md` if you run `/init` in Cursor) so the AI can reference it anytime.
+    - If you would rather not start from a blank prompt, [vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) gives you staged prompts for research, PRD, and technical design, plus a CLI that writes the resulting `AGENTS.md`.
 
 - **Secure Your Secrets**: 
     - Always store API keys, tokens, and other sensitive data in environment files (`.env`). 

--- a/setup_and_planning_guide/README.md
+++ b/setup_and_planning_guide/README.md
@@ -9,6 +9,7 @@
     - Use an AI assistant like Claude or ChatGPT to create a detailed plan in markdown. 
     - Ask it clarifying questions and have it critique its own plan, then regenerate until it's solid. 
     - This plan becomes your instruction manual for the coding process. Save this plan in `plan.md` (or `Claude.md` if you run `/init` in Cursor) so the AI can reference it anytime.
+    - If you would rather not start from a blank prompt, [vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) gives you staged prompts for research, PRD, and technical design, plus a CLI that writes the resulting `AGENTS.md`.
 
 - **Secure Your Secrets**: 
     - Always store API keys, tokens, and other sensitive data in environment files (`.env`). 


### PR DESCRIPTION
Adds one sub-bullet under **Setup and Planning → Create a Comprehensive Plan**, in both `README.md` and `setup_and_planning_guide/README.md` so the two stay in sync.

```markdown
    - If you would rather not start from a blank prompt, [vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) gives you staged prompts for research, PRD, and technical design, plus a CLI that writes the resulting `AGENTS.md`.
```

**Why here:** the guide already recommends starting from a template and having an AI produce a plan you save as `plan.md` / `CLAUDE.md`. This is a concrete, free way to do exactly that — three ordered prompts (deep research → PRD → technical design) that make the AI ask clarifying questions before it writes anything, and an `npx vibeworkflow` CLI that turns the answers into `AGENTS.md` and `agent_docs/`.

It reinforces the guide's own principles (clarity first, iterative control, human oversight) rather than adding a new tool to evaluate. MIT licensed, 2.8k stars, actively maintained. No other content touched.
