### PR TITLE
Add Taskade Genesis as a Web/app builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Keep thinking, be curious, and use AI to increase your coding speed and deepen y
 9. [v0](https://v0.dev)
 10. [Tempo Labs](https://tempolabs.ai)
 
+Web / app builder: [Taskade Genesis](https://www.taskade.com/create) — One prompt → live app with projects, agents, and automations.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Adds [Taskade Genesis](https://www.taskade.com/create) as a **Web / app builder** line after the Top 10, next to Lovable / Bolt / v0 — without expanding the numbered list to #11.

One prompt → live app with projects, agents, and automations.

I work at Taskade.

Made with [Cursor](https://cursor.com)